### PR TITLE
Add alternate unity install path for macos

### DIFF
--- a/lib/fastlane/plugin/unity/helper/unity_helper.rb
+++ b/lib/fastlane/plugin/unity/helper/unity_helper.rb
@@ -23,6 +23,7 @@ module Fastlane
           paths << "C:\\Program Files\\Unity\\Editor\\Unity.exe"
         elsif OS.mac?
           paths << "/Applications/Unity/Hub/Editor/#{unity_version}/Unity.app/Contents/MacOS/Unity" if unity_version
+          paths << "/Applications/Unity #{unity_version}/Unity.app/Contents/MacOS/Unity" if unity_version
           paths << "/Applications/Unity/Unity.app/Contents/MacOS/Unity"
         elsif OS.linux?
           paths << "~/Unity/Hub/Editor/#{unity_version}/Editor/Unity" if unity_version


### PR DESCRIPTION
[Using this unity install commandline wrapper](https://github.com/sttz/install-unity) it installs unity in `/Applications/Unity {VERSION}/` Seems like a safe addition.